### PR TITLE
feat: Make page mobile responsive by hiding elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,12 +98,6 @@
             .stage-card:hover {
                 transform: scale(1.02);
             }
-            .central-title {
-                display: none;
-            }
-            #arrow-canvas {
-                display: none;
-            }
         }
     </style>
 </head>
@@ -116,12 +110,12 @@
 
     <div class="infographic-container">
         <!-- Central Title for Desktop -->
-        <div class="central-title absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-1/3 h-1/3 bg-slate-800 rounded-full flex items-center justify-center text-center shadow-2xl z-20">
+        <div class="central-title hidden md:flex absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-1/3 h-1/3 bg-slate-800 rounded-full items-center justify-center text-center shadow-2xl z-20">
             <h2 class="text-white text-2xl font-bold leading-tight">CI/CD &<br>Continuous<br>Improvement</h2>
         </div>
 
         <!-- Canvas for drawing arrows -->
-        <canvas id="arrow-canvas"></canvas>
+        <canvas id="arrow-canvas" class="hidden md:block"></canvas>
 
         <!-- Stage 1: Requirement Gathering -->
         <div class="stage-card stage-1 bg-white border-t-4 border-blue-500 rounded-xl shadow-lg flex flex-col items-center justify-center p-4 text-center">


### PR DESCRIPTION
Makes the page mobile responsive by hiding the central CI/CD circle and the outer decorative circle on mobile screen sizes.

This is achieved by using Tailwind CSS utility classes (`hidden`, `md:block`, `md:flex`) to control the visibility of the elements based on the screen breakpoint. This is the idiomatic approach for the existing Tailwind CSS setup.